### PR TITLE
Update to use main branch

### DIFF
--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -2,4 +2,4 @@
 directory=glib
 url=https://gitlab.gnome.org/GNOME/glib.git
 push-url=git@gitlab.gnome.org:GNOME/glib.git
-revision=master
+revision=main

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -2,4 +2,4 @@
 directory=harfbuzz
 url=https://github.com/harfbuzz/harfbuzz.git
 push-url=git@github.com:harfbuzz/harfbuzz.git
-revision=master
+revision=main


### PR DESCRIPTION
glib 과 hafbuzz upstream의 master 브랜치 이름이 main으로 변경되면서 기존 빌드가 깨지는 문제를 수정했습니다.