### PR TITLE
Fix pango revision to main

### DIFF
--- a/subprojects/pango.wrap
+++ b/subprojects/pango.wrap
@@ -2,4 +2,4 @@
 directory=pango
 url=https://gitlab.gnome.org/GNOME/pango.git
 push-url=git@gitlab.gnome.org:GNOME/pango.git
-revision=master
+revision=main


### PR DESCRIPTION
Upstream pango의 디폴트 브랜치가 master에서 main으로 변경되어 기존 빌드가 실패하는 문제를 개선합니다.