### PR TITLE
Update wrap files of some subprojects

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,5 +1,8 @@
 [wrap-git]
-directory=freetype2
-url=https://github.com/centricular/freetype2.git
-push-url=git@github.com:centricular/freetype2.git
-revision=meson
+directory=freetype
+url=https://gitlab.freedesktop.org/freetype/freetype.git
+revision=VER-2-11-0
+
+[provide]
+freetype2 = freetype_dep
+freetype = freetype_dep

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,10 +1,11 @@
 [wrap-file]
 directory = zlib-1.2.11
-
 source_url = https://zlib.net/fossils/zlib-1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
 source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+patch_filename = zlib_1.2.11-6_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.2.11-6/get_patch
+patch_hash = f7c24c5698ce787294910ad431f94088102d35ddaf88542d04add1e54afa9212
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/3/get_zip
-patch_filename = zlib-1.2.11-3-wrap.zip
-patch_hash = f07dc491ab3d05daf00632a0591e2ae61b470615b5b73bcf9b3f061fff65cff0
+[provide]
+zlib = zlib_dep


### PR DESCRIPTION
Update freetype2.wrap to pin original(maybe) repository for updated harfbuzz.
Update zlib.wrap to remove dependency while building glib.